### PR TITLE
handle plugin and spec execution on windows

### DIFF
--- a/lib/logstash/inputs/pipe.rb
+++ b/lib/logstash/inputs/pipe.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 if LogStash::Environment.windows?
-  raise Exception("This plugin doesn't not work on Microsoft Windows.")
+  raise Exception("This plugin does not work on Microsoft Windows.")
 end
 require "logstash/inputs/base"
 require "logstash/namespace"

--- a/lib/logstash/inputs/pipe.rb
+++ b/lib/logstash/inputs/pipe.rb
@@ -1,4 +1,7 @@
 # encoding: utf-8
+if LogStash::Environment.windows?
+  raise Exception("This plugin doesn't not work on Microsoft Windows.")
+end
 require "logstash/inputs/base"
 require "logstash/namespace"
 require "socket" # for Socket.gethostname

--- a/lib/logstash/inputs/pipe.rb
+++ b/lib/logstash/inputs/pipe.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require "logstash/environment"
 if LogStash::Environment.windows?
   raise Exception("This plugin does not work on Microsoft Windows.")
 end

--- a/spec/inputs/pipe_spec.rb
+++ b/spec/inputs/pipe_spec.rb
@@ -1,10 +1,8 @@
 # encoding: utf-8
-return if LogStash::Environment.windows?
 require "logstash/devutils/rspec/spec_helper"
 require "tempfile"
 
-describe "inputs/pipe" do
-  
+describe "inputs/pipe", :unix => true do
 
   describe "echo" do
     event_count = 1

--- a/spec/inputs/pipe_spec.rb
+++ b/spec/inputs/pipe_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+return if LogStash::Environment.windows?
 require "logstash/devutils/rspec/spec_helper"
 require "tempfile"
 


### PR DESCRIPTION
This patch skips the test suite when started from Windows, and raises an Exception if the plugin is used on Windows.