### PR TITLE
Make usage of the new shutdown api + small rspec refactor

### DIFF
--- a/logstash-input-pipe.gemspec
+++ b/logstash-input-pipe.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", "~> 2.0.0.snapshot"
-
+  s.add_runtime_dependency 'stud', '~> 0.0.22'
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_development_dependency 'logstash-devutils'
 end

--- a/spec/inputs/pipe_spec.rb
+++ b/spec/inputs/pipe_spec.rb
@@ -1,43 +1,68 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
+require "logstash/inputs/pipe"
 require "tempfile"
 
-describe "inputs/pipe", :unix => true do
+describe LogStash::Inputs::Pipe, :unix => true do
 
-  # rince and repeat a few times to stress the shutdown sequence
-  5.times.each do
-    it "should pipe from echo" do
-      conf = <<-CONFIG
+  it "should register" do
+    input = LogStash::Plugin.lookup("input", "pipe").new("command" => "echo 'world'")
+
+    # register will try to load jars and raise if it cannot find jars or if org.apache.log4j.spi.LoggingEvent class is not present
+    expect {input.register}.to_not raise_error
+  end
+
+  context "when interrupting the plugin" do
+
+    it_behaves_like "an interruptible input plugin" do
+      let(:config) { { "command" => "echo ☹" } }
+    end
+
+    it_behaves_like "an interruptible input plugin" do
+      let(:config) { { "command" => "echo foo" } }
+    end
+
+  end
+
+  describe "pipe from echo" do
+
+    let(:config) do <<-CONFIG
       input {
         pipe {
           command => "echo ☹"
         }
       }
-      CONFIG
+    CONFIG
+    end
 
-      event = input(conf) do |pipeline, queue|
+    let(:event) do
+      input(config) do |pipeline, queue|
         queue.pop
       end
-
-      insist { event["message"] } == "☹"
     end
+
+    it "should receive the pipe" do
+      expect(event["message"]).to eq("☹")
+    end
+
   end
 
-  # rince and repeat a few times to stress the shutdown sequence
-  5.times.each do
-    it "should pipe from tail -f" do
-      event_count = 10
-      tmp_file = Tempfile.new('logstash-spec-input-pipe')
+  describe "pipe from tail" do
 
-      conf = <<-CONFIG
-      input {
+    let(:tmp_file)    { Tempfile.new('logstash-spec-input-pipe') }
+    let(:event_count) { 10 }
+
+    let(:config) do <<-CONFIG
+    input {
         pipe {
           command => "tail -n +0 -f #{tmp_file.path}"
         }
       }
-      CONFIG
+    CONFIG
+    end
 
-      events = input(conf) do |pipeline, queue|
+    let(:events) do
+      input(config) do |pipeline, queue|
         File.open(tmp_file, "a") do |fd|
           event_count.times do |i|
             # unicode smiley for testing unicode support!
@@ -46,9 +71,11 @@ describe "inputs/pipe", :unix => true do
         end
         event_count.times.map { queue.pop }
       end
+    end
 
+    it "should receive all piped elements" do
       event_count.times do |i|
-        insist { events[i]["message"] } == "#{i} ☹"
+        expect(events[i]["message"]).to eq("#{i} ☹")
       end
     end
   end


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3812

Fixes #11 