### PR TITLE
Doc: separate explanation from preceding TODO.

### DIFF
--- a/lib/logstash/inputs/pipe.rb
+++ b/lib/logstash/inputs/pipe.rb
@@ -17,7 +17,8 @@ class LogStash::Inputs::Pipe < LogStash::Inputs::Base
   config_name "pipe"
 
   # TODO(sissel): This should switch to use the `line` codec by default
-  # once we switch away from doing 'readline'
+  # once we switch away from doing 'readline'.
+  #
   default :codec, "plain"
 
   # Command to run and read events from, one line at a time.


### PR DESCRIPTION
**I think the TODO shouln't appear in the documentation, just in the code.
But I don't know the syntax to accomplish that.**