### PR TITLE
Change multiline filter to multiline codec 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.3
+  - Docs: Remove mention of the multiline filter plugin because it's no longer supported
+
 ## 3.0.2
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/lib/logstash/inputs/pipe.rb
+++ b/lib/logstash/inputs/pipe.rb
@@ -11,7 +11,7 @@ require "stud/interval"
 # Stream events from a long running command pipe.
 #
 # By default, each event is assumed to be one line. If you
-# want to join lines, you'll want to use the multiline filter.
+# want to join lines, you'll want to use the multiline codec.
 #
 class LogStash::Inputs::Pipe < LogStash::Inputs::Base
   config_name "pipe"

--- a/logstash-input-pipe.gemspec
+++ b/logstash-input-pipe.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-pipe'
-  s.version         = '3.0.2'
+  s.version         = '3.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Stream events from a long running command pipe"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Changes for https://github.com/elastic/logstash/issues/6342

Removes mention of multiline filter plugin from the source for the plugin docs.

