### PR TITLE
Feat: adjust fields for ECS compatibility

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -27,6 +27,21 @@ By default, each event is assumed to be one line. If you
 want to join lines, you'll want to use the multiline codec.
 
 
+[id="plugins-{type}s-{plugin}-ecs"]
+==== Compatibility with the Elastic Common Schema (ECS)
+
+This plugin adds extra fields about the event's source, and can be configured to do so
+in an {ecs-ref}[ECS-compatible] way with <<plugins-{type}s-{plugin}-ecs_compatibility>>.
+These fields are added after the event has been decoded by the appropriate codec,
+and will not overwrite existing values.
+
+|========
+| ECS Disabled | ECS v1 , v8               | Description
+
+| `host`       | `[host][name]`            | The name of the {ls} host that processed the event
+| `command`    | `[process][command_line]` | The command run by the plugin
+|========
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== Pipe Input Configuration Options
 
@@ -36,6 +51,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-command>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -54,8 +70,51 @@ Command to run and read events from, one line at a time.
 
 Example:
 [source,ruby]
-   command => "echo hello world"
+-----
+input {
+  pipe {
+    command => "echo ¡Hola!"
+  }
+}
+-----
 
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: uses backwards compatible field names, such as `[host]`
+    ** `v1`, `v8`: uses fields that are compatible with ECS, such as `[host][name]`
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+See <<plugins-{type}s-{plugin}-ecs>> for detailed information.
+
+
+**Sample output: ECS enabled**
+[source,ruby]
+-----
+{
+    "@timestamp"=>2021-11-16T09:18:45.306Z,
+    "message" => "¡Hola!",
+    "process" => {
+        "command_line" => "echo '¡Hola!'"
+    },
+    "host" => {
+        "name" => "deus-ex-machina"
+    },
+}
+-----
+
+**Sample output: ECS disabled**
+[source,ruby]
+-----
+{
+    "@timestamp"=>2021-11-16T09:18:45.306Z,
+    "message" => "¡Hola!",
+    "command" => "echo '¡Hola!'",
+    "host" => "deus-ex-machina"
+}
+-----
 
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -101,7 +101,7 @@ See <<plugins-{type}s-{plugin}-ecs>> for detailed information.
     },
     "host" => {
         "name" => "deus-ex-machina"
-    },
+    }
 }
 -----
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -30,8 +30,10 @@ want to join lines, you'll want to use the multiline codec.
 [id="plugins-{type}s-{plugin}-ecs"]
 ==== Compatibility with the Elastic Common Schema (ECS)
 
-This plugin adds extra fields about the event's source, and can be configured to do so
-in an {ecs-ref}[ECS-compatible] way with <<plugins-{type}s-{plugin}-ecs_compatibility>>.
+This plugin adds extra fields about the event's source. 
+Configure the <<plugins-{type}s-{plugin}-ecs_compatibility>> option if you want
+to ensure that these fields are compatible with {ecs-ref}[ECS].
+
 These fields are added after the event has been decoded by the appropriate codec,
 and will not overwrite existing values.
 

--- a/lib/logstash/inputs/pipe.rb
+++ b/lib/logstash/inputs/pipe.rb
@@ -8,12 +8,17 @@ require "logstash/namespace"
 require "socket" # for Socket.gethostname
 require "stud/interval"
 
+require 'logstash/plugin_mixins/ecs_compatibility_support'
+
 # Stream events from a long running command pipe.
 #
 # By default, each event is assumed to be one line. If you
 # want to join lines, you'll want to use the multiline codec.
 #
 class LogStash::Inputs::Pipe < LogStash::Inputs::Base
+
+  include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8 => :v1)
+
   config_name "pipe"
 
   # TODO(sissel): This should switch to use the `line` codec by default
@@ -37,6 +42,9 @@ class LogStash::Inputs::Pipe < LogStash::Inputs::Base
     @logger.debug("Registering pipe input", :command => @command)
 
     @hostname = Socket.gethostname.freeze
+
+    @host_name_field =            ecs_select[disabled: 'host',    v1: '[host][name]']
+    @process_command_line_field = ecs_select[disabled: 'command', v1: '[process][command_line]']
   end # def register
 
   public
@@ -48,10 +56,11 @@ class LogStash::Inputs::Pipe < LogStash::Inputs::Base
         pipe.each do |line|
           line = line.chomp
           @logger.debug? && @logger.debug("Received line", :command => @command, :line => line)
+
           @codec.decode(line) do |event|
-            event.set("host", @hostname)
-            event.set("command", @command)
             decorate(event)
+            event.set(@host_name_field, @hostname) unless event.include?(@host_name_field)
+            event.set(@process_command_line_field, @command) unless event.include?(@process_command_line_field)
             queue << event
           end
         end

--- a/logstash-input-pipe.gemspec
+++ b/logstash-input-pipe.gemspec
@@ -21,8 +21,10 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'stud', '~> 0.0.22'
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
   s.add_runtime_dependency 'logstash-codec-plain'
+  s.add_runtime_dependency 'stud', '~> 0.0.22'
+
   s.add_development_dependency 'logstash-devutils'
 end
 

--- a/spec/inputs/pipe_spec.rb
+++ b/spec/inputs/pipe_spec.rb
@@ -98,9 +98,8 @@ describe LogStash::Inputs::Pipe, :unix => true do
     end
 
     it "should receive all piped elements" do
-      event_count.times do |i|
-        expect(events[i].get("message")).to eq("#{i} ☹")
-      end
+      messages = event_count.times.map { |i| events[i].get("message") }
+      expect( messages.sort ).to eql event_count.times.map { |i| "#{i} ☹" }
     end
   end
 end

--- a/spec/inputs/pipe_spec.rb
+++ b/spec/inputs/pipe_spec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/devutils/rspec/shared_examples"
+require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 require "logstash/inputs/pipe"
 require "tempfile"
 
@@ -25,25 +26,47 @@ describe LogStash::Inputs::Pipe, :unix => true do
 
   end
 
-  describe "pipe from echo" do
+  describe "pipe from echo", :ecs_compatibility_support do
 
-    let(:config) do <<-CONFIG
-      input {
-        pipe {
-          command => "echo ☹"
+    ecs_compatibility_matrix(:disabled, :v1, :v8) do |ecs_select|
+
+      let(:config) do <<-CONFIG
+        input {
+          pipe {
+            command => "echo ☹"
+            ecs_compatibility => "#{ecs_compatibility}"
+          }
         }
-      }
-    CONFIG
-    end
-
-    let(:event) do
-      input(config) do |pipeline, queue|
-        queue.pop
+      CONFIG
       end
-    end
 
-    it "should receive the pipe" do
-      expect(event.get("message")).to eq("☹")
+      let(:event) do
+        input(config) do |pipeline, queue|
+          queue.pop
+        end
+      end
+
+      it "should receive the pipe" do
+        expect(event.get("message")).to eq("☹")
+      end
+
+      it "sets host field" do
+        if ecs_select.active_mode == :disabled
+          expect(event.get("host")).to be_a String
+        else
+          expect(event.get("[host][name]")).to be_a String
+        end
+      end
+
+      it "sets the command executed" do
+        if ecs_select.active_mode == :disabled
+          expect(event.get("command")).to eql "echo ☹"
+        else
+          expect(event.include?("command")).to be false
+          expect(event.get("[process][command_line]")).to eql "echo ☹"
+        end
+      end
+
     end
 
   end


### PR DESCRIPTION
Previously plugin was setting the top level `command` and `host` fields for every event (which aren't ECS compliant).

There's a change in behavior to **not override** fields if they exists in the decoded payload (e.g. no longer force the `host` field if such a field is decoded from the command's output).

Also avoid an unnecessary `undefined method `close' for nil` when a different thread stops the plugin.
Plugin changes are similar to it's input exec cousin: https://github.com/logstash-plugins/logstash-input-exec/pull/28